### PR TITLE
fix: improve sh-stat-card hover effect and sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2025-01-16
+
+### Changed
+- **sh-stat-card**: Amélioration de l'UX et du design
+  - Effet hover : bordure primary au lieu de changement de background (plus cohérent avec les autres composants)
+  - Hauteur réduite : `min-height: 72px` (vs 88px) pour meilleur centrage dans NavSection
+  - Padding optimisé : `var(--spacing-xs) var(--spacing-sm)` pour un design plus compact
+  - Gap réduit entre valeur et label : `var(--spacing-2xs)` pour meilleure lisibilité
+
+## [1.3.0] - 2025-01-16
+
 ### Added
 - **sh-stat-card**: Nouveau composant molecule pour filtrage interactif des prédictions par niveau de risque
   - Design minimaliste pour affichage de statistiques (valeur + label)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stockhub/design-system",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "description": "Design system for StockHub application",
   "main": "dist/stockhub-design-system.umd.js",

--- a/src/components/molecules/stat-card/sh-stat-card.ts
+++ b/src/components/molecules/stat-card/sh-stat-card.ts
@@ -99,7 +99,7 @@ export class ShStatCard extends LitElement {
       background: var(--card-bg);
       border: 2px solid var(--card-border);
       border-radius: var(--border-radius-lg);
-      padding: var(--spacing-md) var(--spacing-sm);
+      padding: var(--spacing-xs) var(--spacing-sm);
       text-align: center;
       cursor: pointer;
       transition: all 0.2s ease;
@@ -108,14 +108,14 @@ export class ShStatCard extends LitElement {
       flex-direction: column;
       justify-content: center;
       align-items: center;
-      gap: var(--spacing-xs);
-      min-height: 88px;
+      gap: var(--spacing-2xs);
+      min-height: 72px;
     }
 
     .stat-card:hover {
-      background: var(--card-hover-bg);
+      border-color: var(--color-primary-400);
       transform: translateY(-2px);
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+      box-shadow: 0 4px 12px rgba(139, 92, 246, 0.15);
     }
 
     /* Selected state styling */


### PR DESCRIPTION
## Changes

- **Hover effect improvement**: Change from background change to primary border + shadow (more consistent with other components)
- **Better sizing**: Reduce min-height from 88px to 72px for better centering in NavSection
- **Optimized padding**: Use `var(--spacing-xs) var(--spacing-sm)` for more compact design
- **Reduced gap**: Use `var(--spacing-2xs)` between value and label for better readability

## Testing

✅ Tested in Storybook - all stories render correctly
✅ Tested in front-end Analytics page - cards are well centered in NavSection
✅ Hover effect is more elegant and consistent

## Version

Bumped to v1.3.1 (patch release)

Closes #9