### PR TITLE
fix(a11y): map aria-label attribute to ariaLabel property in sh-button — closes #28

### DIFF
--- a/src/components/molecules/button/sh-button.ts
+++ b/src/components/molecules/button/sh-button.ts
@@ -85,7 +85,7 @@ export class ShButton extends LitElement {
    * Accessible label for screen readers (required for icon-only buttons)
    * @type {string}
    */
-  @property({ type: String }) ariaLabel: string | null = null;
+  @property({ type: String, attribute: 'aria-label' }) ariaLabel: string | null = null;
 
   static styles = css`
     :host {


### PR DESCRIPTION
## Summary

- `sh-button.ts` : ajout de `attribute: 'aria-label'` sur le décorateur `@property` de `ariaLabel`

Sans cette correction, Lit écoutait l'attribut `arialabel` (tout en minuscules) au lieu de `aria-label` (avec tiret), donc la prop n'était jamais propagée au `<button>` interne dans le Shadow DOM.

## Fichiers modifiés

- `src/components/molecules/button/sh-button.ts`

## Test plan

- [x] Build passe sans erreur
- [ ] `<sh-button aria-label="...">` propage le label au `<button>` interne
- [ ] Lighthouse `button-name` ne signale plus d'erreur sur StockHub frontend
- [ ] Storybook : tester un bouton icon-only avec aria-label

Closes #28