### PR TITLE
fix!: renommer les événements custom non conformes avec le préfixe sh-

### DIFF
--- a/ETAT-DU-PROJET.md
+++ b/ETAT-DU-PROJET.md
@@ -49,6 +49,10 @@ Au passage : le label `technique` référencé par le template d'issue `.github/
 
 - **#41** — Migration ESLint 9 flat config, `npm run lint` fonctionne de nouveau (0 erreur, 70 warnings pré-existants inchangés). Détail et alternatives pesées : [ADR 0001](documentation/adr/0001-migration-eslint-flat-config.md).
 
+### En cours — PR ouverte, pas encore mergée
+
+- **#42** — Renommage des 7 événements custom avec préfixe `sh-` (branche `fix/42-event-naming-conventions`). **Breaking change confirmé** : `stockHub_V2_front` (pinné `v1.3.3`) consomme déjà les anciens noms dans 4 fichiers — issue de suivi ouverte : [stockHub_V2_front#192](https://github.com/SandrineCipolla/stockHub_V2_front/issues/192). Détail : [ADR 0002](documentation/adr/0002-renommage-evenements-prefixe-sh.md).
+
 ---
 
 ## Où en est le projet

--- a/documentation/adr/0002-renommage-evenements-prefixe-sh.md
+++ b/documentation/adr/0002-renommage-evenements-prefixe-sh.md
@@ -1,0 +1,58 @@
+# 0002. Renommer 7 événements custom non conformes avec le préfixe `sh-`
+
+**Statut** : Acceptée
+**Date** : 10 juillet 2026
+**Issue** : #42
+
+## Contexte
+
+`npm run audit:conventions` (gate CI) échouait sur 7 événements custom
+introduits par la PR #37 (issue #35 — RoleSelector, CollaboratorList,
+ContributionForm, ContributionCard) : aucun ne respectait la règle
+`isShPrefix` d'`audit-conventions.cjs`, qui exige que tout événement
+custom commence par `sh-` (cohérent avec les événements déjà en place,
+ex. `sh-metric-click`, `sh-stat-click`).
+
+Ces événements ne sont pas un détail interne : `stockHub_V2_front`
+(pinné sur le tag `v1.3.3` du DS) les consomme déjà dans 4 fichiers
+(`ContributionFormModal.tsx`, `CollaboratorsModal.tsx`,
+`PendingContributionsSection.tsx`, `web-components.d.ts`). Renommer un
+événement public sans coordination casserait silencieusement ces usages.
+
+## Décision
+
+Renommer les 7 événements avec le préfixe `sh-`, sans période de
+transition ni double-émission :
+
+| Ancien nom | Nouveau nom |
+|---|---|
+| `contribution-approve` | `sh-contribution-approve` |
+| `contribution-reject` | `sh-contribution-reject` |
+| `contribution-submit` | `sh-contribution-submit` |
+| `contribution-cancel` | `sh-contribution-cancel` |
+| `role-change` | `sh-role-change` |
+| `collaborator-role-change` | `sh-collaborator-role-change` |
+| `collaborator-remove` | `sh-collaborator-remove` |
+
+## Alternatives envisagées
+
+- **Dual-dispatch temporaire** (émettre l'ancien et le nouveau nom en
+  parallèle) : évitait la casse immédiate côté Front, mais ajoutait de
+  la dette (code à nettoyer plus tard, deux noms qui cohabitent) pour un
+  gain limité — ces composants viennent d'être livrés (PR #37, avril
+  2026), la fenêtre de coordination avec le seul consommateur (Front)
+  est courte.
+- **Ignorer l'audit sur ces 4 composants** (exception dans
+  `audit-conventions.cjs`) : rejeté, ça viderait la gate de son sens et
+  créerait un précédent pour ne jamais corriger la dette de nommage.
+
+## Conséquences
+
+- Breaking change assumé, versionné comme tel (commit `fix!:` avec
+  footer `BREAKING CHANGE`, release-please doit faire un bump majeur).
+- Issue de suivi ouverte côté Front pour coordonner la mise à jour des 4
+  fichiers consommateurs avant d'installer une version du DS postérieure
+  à `v1.3.3` : [stockHub_V2_front#192](https://github.com/SandrineCipolla/stockHub_V2_front/issues/192).
+- Constat séparé, pas traité ici : le README du DS ne documentait déjà
+  pas ces 4 composants depuis leur ajout — flaggé comme tâche de fond
+  indépendante, pas un blocage pour ce renommage.

--- a/src/components/molecules/contribution-card/sh-contribution-card.stories.ts
+++ b/src/components/molecules/contribution-card/sh-contribution-card.stories.ts
@@ -159,8 +159,8 @@ export const InteractiveDemo: Story = {
         }
 
         if (card) {
-          card.addEventListener('contribution-approve', (e) => addEntry('contribution-approve', e.detail, '#4ade80'));
-          card.addEventListener('contribution-reject', (e) => addEntry('contribution-reject', e.detail, '#f87171'));
+          card.addEventListener('sh-contribution-approve', (e) => addEntry('sh-contribution-approve', e.detail, '#4ade80'));
+          card.addEventListener('sh-contribution-reject', (e) => addEntry('sh-contribution-reject', e.detail, '#f87171'));
         }
       });
     </script>

--- a/src/components/molecules/contribution-card/sh-contribution-card.ts
+++ b/src/components/molecules/contribution-card/sh-contribution-card.ts
@@ -15,8 +15,8 @@ const STATUS_CONFIG: Record<ContributionStatus, { label: string; icon: string; c
  *
  * @element sh-contribution-card
  *
- * @fires contribution-approve - Émis au clic "Approuver". `detail: { contributionId: string }`
- * @fires contribution-reject  - Émis au clic "Rejeter".  `detail: { contributionId: string }`
+ * @fires sh-contribution-approve - Émis au clic "Approuver". `detail: { contributionId: string }`
+ * @fires sh-contribution-reject  - Émis au clic "Rejeter".  `detail: { contributionId: string }`
  *
  * @example
  * ```html
@@ -247,7 +247,7 @@ export class ShContributionCard extends LitElement {
 
   private handleApprove() {
     this.dispatchEvent(
-      new CustomEvent('contribution-approve', {
+      new CustomEvent('sh-contribution-approve', {
         detail: { contributionId: this.contributionId },
         bubbles: true,
         composed: true,
@@ -257,7 +257,7 @@ export class ShContributionCard extends LitElement {
 
   private handleReject() {
     this.dispatchEvent(
-      new CustomEvent('contribution-reject', {
+      new CustomEvent('sh-contribution-reject', {
         detail: { contributionId: this.contributionId },
         bubbles: true,
         composed: true,

--- a/src/components/molecules/contribution-form/sh-contribution-form.stories.ts
+++ b/src/components/molecules/contribution-form/sh-contribution-form.stories.ts
@@ -81,8 +81,8 @@ export const InteractiveDemo: Story = {
         }
 
         if (form) {
-          form.addEventListener('contribution-submit', (e) => addEntry('contribution-submit', e.detail, '#8b5cf6'));
-          form.addEventListener('contribution-cancel', () => addEntry('contribution-cancel', null, '#94a3b8'));
+          form.addEventListener('sh-contribution-submit', (e) => addEntry('sh-contribution-submit', e.detail, '#8b5cf6'));
+          form.addEventListener('sh-contribution-cancel', () => addEntry('sh-contribution-cancel', null, '#94a3b8'));
         }
       });
     </script>

--- a/src/components/molecules/contribution-form/sh-contribution-form.ts
+++ b/src/components/molecules/contribution-form/sh-contribution-form.ts
@@ -6,8 +6,8 @@ import { customElement, property, state } from 'lit/decorators.js';
  *
  * @element sh-contribution-form
  *
- * @fires contribution-submit - Émis à la soumission. `detail: { suggestedQuantity: number }`
- * @fires contribution-cancel - Émis à l'annulation.
+ * @fires sh-contribution-submit - Émis à la soumission. `detail: { suggestedQuantity: number }`
+ * @fires sh-contribution-cancel - Émis à l'annulation.
  *
  * @example
  * ```html
@@ -184,7 +184,7 @@ export class ShContributionForm extends LitElement {
       return;
     }
     this.dispatchEvent(
-      new CustomEvent('contribution-submit', {
+      new CustomEvent('sh-contribution-submit', {
         detail: { suggestedQuantity: this.suggestedQuantity },
         bubbles: true,
         composed: true,
@@ -193,7 +193,7 @@ export class ShContributionForm extends LitElement {
   }
 
   private handleCancel() {
-    this.dispatchEvent(new CustomEvent('contribution-cancel', { bubbles: true, composed: true }));
+    this.dispatchEvent(new CustomEvent('sh-contribution-cancel', { bubbles: true, composed: true }));
   }
 
   render() {

--- a/src/components/molecules/role-selector/sh-role-selector.stories.ts
+++ b/src/components/molecules/role-selector/sh-role-selector.stories.ts
@@ -6,7 +6,7 @@ const meta: Meta = {
   component: 'sh-role-selector',
   parameters: {
     layout: 'centered',
-    actions: { handles: ['role-change'] },
+    actions: { handles: ['sh-role-change'] },
   },
   tags: ['autodocs'],
   argTypes: {

--- a/src/components/molecules/role-selector/sh-role-selector.ts
+++ b/src/components/molecules/role-selector/sh-role-selector.ts
@@ -14,7 +14,7 @@ const ROLE_OPTIONS: { value: StockRole; label: string }[] = [
  *
  * @element sh-role-selector
  *
- * @fires role-change - Émis quand le rôle change. `detail: { role: StockRole }`
+ * @fires sh-role-change - Émis quand le rôle change. `detail: { role: StockRole }`
  *
  * @example
  * ```html
@@ -92,7 +92,7 @@ export class ShRoleSelector extends LitElement {
     const select = e.target as HTMLSelectElement;
     this.value = select.value as StockRole;
     this.dispatchEvent(
-      new CustomEvent('role-change', {
+      new CustomEvent('sh-role-change', {
         detail: { role: this.value },
         bubbles: true,
         composed: true,

--- a/src/components/organisms/collaborator-list/sh-collaborator-list.stories.ts
+++ b/src/components/organisms/collaborator-list/sh-collaborator-list.stories.ts
@@ -128,11 +128,11 @@ export const InteractiveDemo: Story = {
         }
 
         if (list) {
-          list.addEventListener('collaborator-role-change', (e) => {
-            addEntry('collaborator-role-change', e.detail, '#60a5fa');
+          list.addEventListener('sh-collaborator-role-change', (e) => {
+            addEntry('sh-collaborator-role-change', e.detail, '#60a5fa');
           });
-          list.addEventListener('collaborator-remove', (e) => {
-            addEntry('collaborator-remove', e.detail, '#f87171');
+          list.addEventListener('sh-collaborator-remove', (e) => {
+            addEntry('sh-collaborator-remove', e.detail, '#f87171');
           });
         }
       });

--- a/src/components/organisms/collaborator-list/sh-collaborator-list.ts
+++ b/src/components/organisms/collaborator-list/sh-collaborator-list.ts
@@ -16,8 +16,8 @@ export interface CollaboratorItem {
  *
  * @element sh-collaborator-list
  *
- * @fires collaborator-role-change - Émis quand un rôle est modifié. `detail: { collaboratorId: number, role: StockRole }`
- * @fires collaborator-remove - Émis quand un collaborateur est retiré. `detail: { collaboratorId: number }`
+ * @fires sh-collaborator-role-change - Émis quand un rôle est modifié. `detail: { collaboratorId: number, role: StockRole }`
+ * @fires sh-collaborator-remove - Émis quand un collaborateur est retiré. `detail: { collaboratorId: number }`
  *
  * @example
  * ```html
@@ -178,7 +178,7 @@ export class ShCollaboratorList extends LitElement {
 
   private handleRoleChange(collaboratorId: number, e: CustomEvent) {
     this.dispatchEvent(
-      new CustomEvent('collaborator-role-change', {
+      new CustomEvent('sh-collaborator-role-change', {
         detail: { collaboratorId, role: e.detail.role },
         bubbles: true,
         composed: true,
@@ -188,7 +188,7 @@ export class ShCollaboratorList extends LitElement {
 
   private handleRemove(collaboratorId: number) {
     this.dispatchEvent(
-      new CustomEvent('collaborator-remove', {
+      new CustomEvent('sh-collaborator-remove', {
         detail: { collaboratorId },
         bubbles: true,
         composed: true,
@@ -224,7 +224,7 @@ export class ShCollaboratorList extends LitElement {
                         value="${c.role}"
                         exclude="${this.getExcludedRoles()}"
                         ?disabled="${this.disabled}"
-                        @role-change="${(e: CustomEvent) => this.handleRoleChange(c.id, e)}"
+                        @sh-role-change="${(e: CustomEvent) => this.handleRoleChange(c.id, e)}"
                       ></sh-role-selector>
                     `
                   : html`<sh-role-badge role="${c.role}"></sh-role-badge>`}


### PR DESCRIPTION
## 🔗 Issue liée
Closes #42

## 📋 Description
Les 7 événements custom de sh-contribution-card, sh-contribution-form, sh-role-selector et sh-collaborator-list (PR #37) ne respectaient pas la convention de préfixe `sh-` vérifiée par `npm run audit:conventions`. Ce PR les renomme, met à jour tous les points d'émission/écoute (y compris un listener imbriqué sh-role-selector → sh-collaborator-list) et les stories de démonstration.

## ⚠️ Breaking change
Renommage sans période de transition. `stockHub_V2_front` (pinné sur le tag `v1.3.3`) consomme déjà les anciens noms dans 4 fichiers — issue de suivi ouverte côté Front : SandrineCipolla/stockHub_V2_front#192. Le commit contient un footer `BREAKING CHANGE` pour que release-please fasse un bump majeur.

## 🔧 Détails d'implémentation
- Renommage : contribution-approve/reject, contribution-submit/cancel, role-change, collaborator-role-change, collaborator-remove → équivalents préfixés sh-
- JSDoc `@fires`, `new CustomEvent(...)`, listener Lit `@role-change` → `@sh-role-change` sur le `<sh-role-selector>` imbriqué dans `<sh-collaborator-list>`
- Stories mises à jour (`addEventListener`)
- Contexte et alternatives pesées (dual-dispatch envisagé et rejeté) : `documentation/adr/0002-renommage-evenements-prefixe-sh.md`
- Revue par l'agent code-reviewer du repo avant ouverture de la PR (complétude du renommage confirmée, aucune autre relation d'imbrication manquée)

## ✅ Checklist
- [x] `npm run audit:conventions` : 0 problème (était 7)
- [x] `npm run lint` : 0 erreur
- [x] `npm run build` : passant
- [ ] Issue de suivi Front mergée avant d'installer cette version côté Front
- [ ] GitHub Project mis à jour

## 📸 Screenshots
Aucun changement UI.