### PR TITLE
fix(ci): générer preview-stats.json pour TurboSnap Chromatic

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test-storybook": "test-storybook",
     "test-storybook:ci": "test-storybook --url http://localhost:6006",
     "storybook": "npm run analyze && storybook dev -p 6006",
-    "build-storybook": "npm run analyze && storybook build",
+    "build-storybook": "npm run analyze && storybook build --stats-json",
     "prepare": "npm run build",
     "prepublishOnly": "npm run build:lib",
     "tokens:generate": "tsx src/tokens/generate-css.ts",


### PR DESCRIPTION
## 🔗 Issue liée
Closes #45

## 📋 Description
Le job CI "chromatic" échouait systématiquement (confirmé sur les 5 derniers runs de master et sur la PR #44) : TurboSnap (`onlyChanged: true` sur `chromaui/action@v1`) exige un fichier `preview-stats.json` que `npm run build-storybook` ne générait pas.

## 🔧 Détails d'implémentation
- `package.json` : ajout du flag `--stats-json` à la commande `storybook build`
- Vérifié en local : `storybook-static/preview-stats.json` généré avec succès après build
- Alternative envisagée et écartée : désactiver `onlyChanged` (TurboSnap) plutôt que le réparer — rejetée, TurboSnap accélère les builds Chromatic sur un repo qui grossit, pas de raison de le désactiver alors que le fix est trivial

## ✅ Checklist
- [x] Build local : `preview-stats.json` généré
- [ ] Job "chromatic" vert sur cette PR (à vérifier après ouverture)
- [ ] GitHub Project mis à jour

## 📸 Screenshots
Aucun changement UI.