### PR TITLE
docs: documenter les composants de la PR #37 dans le README

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,60 +255,6 @@ Carte métrique pour afficher des KPIs avec icône, valeur et tendance.
 ></sh-metric-card>
 ```
 
-#### `<sh-stock-item-card>` 🆕 NOUVEAU
-Carte de produit pour l'inventaire familial avec statut, métriques et actions.
-
-**Props** :
-- `name`: string - Nom du produit
-- `sku`: string - Code SKU du produit
-- `quantity`: string | number - Quantité en stock
-- `value`: string - Valeur totale (optionnel)
-- `location`: string - Emplacement (optionnel, ex: "Atelier - Étagère 3")
-- `status`: `"optimal"` | `"low"` | `"critical"` | `"out-of-stock"` | `"overstocked"`
-- `loading`: boolean - État de chargement
-- `theme`: `"light"` | `"dark"`
-
-**Événements** :
-- `sh-view-click` - Émis au clic sur "Voir"
-- `sh-edit-click` - Émis au clic sur "Éditer"
-- `sh-delete-click` - Émis au clic sur "Supprimer"
-
-```html
-<!-- Produit en stock optimal -->
-<sh-stock-item-card
-  name="Peinture Acrylique 500ml - Bleu Cobalt"
-  sku="PNT-001"
-  quantity="45"
-  value="€675"
-  location="Atelier - Étagère 3"
-  status="optimal"
-></sh-stock-item-card>
-
-<!-- Stock faible -->
-<sh-stock-item-card
-  name="Crayons Aquarelle (Boîte de 24)"
-  sku="CRY-042"
-  quantity="8"
-  value="€240"
-  location="Bureau - Tiroir 2"
-  status="low"
-></sh-stock-item-card>
-
-<!-- Écouter les événements -->
-<script>
-  const card = document.querySelector('sh-stock-item-card');
-  card.addEventListener('sh-view-click', (e) => {
-    console.log('View:', e.detail); // { name, sku, status }
-  });
-  card.addEventListener('sh-edit-click', (e) => {
-    console.log('Edit:', e.detail);
-  });
-  card.addEventListener('sh-delete-click', (e) => {
-    console.log('Delete:', e.detail);
-  });
-</script>
-```
-
 #### `<sh-button>` ⚡ AMÉLIORÉ
 Bouton avec variants, états, et support d'icônes.
 
@@ -545,6 +491,161 @@ Carte de prédiction ML pour afficher les ruptures de stock prévues avec analys
 Header de l'application.
 ```html
 <sh-header userName="Sandrine" isLoggedIn></sh-header>
+```
+
+#### `<sh-footer>`
+Footer de l'application avec copyright dynamique et liens légaux.
+
+**Props** :
+- `app-name`: string (défaut : `"STOCK HUB"`)
+- `year`: string (défaut : année courante)
+- `theme`: `"light"` | `"dark"`
+
+**Événements** :
+- `sh-footer-link-click` - Émis au clic sur un lien. `detail: { link: string }`
+
+```html
+<sh-footer
+  app-name="STOCK HUB"
+  year="2025"
+></sh-footer>
+```
+
+#### `<sh-page-header>`
+En-tête de page avec fil d'Ariane (breadcrumb), titre, sous-titre et boutons d'action.
+
+**Props** :
+- `title`: string
+- `subtitle`: string
+- `breadcrumb`: `BreadcrumbItem[]` - `{ label: string, href?: string }[]`
+- `actions`: `ActionButton[]` - `{ label: string, icon?: string, variant?: "primary" | "secondary" | "ghost", handler: string, ariaLabel?: string }[]`
+- `theme`: `"light"` | `"dark"`
+
+**Événements** :
+- `sh-breadcrumb-click` - Émis au clic sur un item du breadcrumb. `detail: { item: BreadcrumbItem, index: number }`
+- `sh-action-{handler}` - Émis au clic sur un bouton d'action (nom dynamique basé sur `action.handler`, ex: `sh-action-edit`). `detail: { action: ActionButton }`
+
+```html
+<sh-page-header
+  title="Tableau de Bord"
+  subtitle="Bienvenue dans votre espace de gestion de stocks intelligent"
+></sh-page-header>
+```
+
+#### `<sh-ia-alert-banner>`
+Bandeau d'alertes IA pour les stocks nécessitant attention, avec liste déroulante des alertes détaillées.
+
+**Props** :
+- `count`: number - Nombre d'alertes
+- `severity`: `"critical"` | `"warning"` | `"info"` (défaut : `"critical"`)
+- `message`: string (défaut : `"stocks nécessitent votre attention"`)
+- `alerts`: `IaAlert[]` - `{ product: string, message: string, severity: "critical" | "warning" | "info" }[]`
+- `expanded`: boolean (défaut : `true`) - Affiche la liste des alertes
+- `theme`: `"light"` | `"dark"`
+
+**Événements** :
+- `sh-ia-alert-toggle` - Émis au clic sur le bouton collapse/expand. `detail: { expanded: boolean }`
+- `sh-ia-alert-item-click` - Émis au clic sur un item de la liste. `detail: IaAlert`
+
+```html
+<sh-ia-alert-banner
+  count="5"
+  severity="critical"
+></sh-ia-alert-banner>
+```
+
+#### `<sh-stock-card>`
+Carte de stock pour le dashboard avec statut, métriques et actions.
+
+**Props** :
+- `name`: string - Nom du stock
+- `category`: string
+- `last-update`: string - Date de dernière mise à jour (ex: "il y a 3h")
+- `percentage`: string | number - Pourcentage de stock (défaut : `"0"`)
+- `quantity`: string - Quantité affichée en sous-label
+- `value`: string - Valeur totale
+- `status`: `"optimal"` | `"low"` | `"critical"` | `"out-of-stock"` | `"overstocked"` (défaut : `"optimal"`)
+- `ia-count`: number - Nombre de suggestions IA (affiche un badge si > 0)
+- `loading`: boolean - Désactive les actions
+- `hide-details`: boolean - Masque le bouton "Détails"
+- `theme`: `"light"` | `"dark"`
+
+**Slots** :
+- `default` - Contenu personnalisé additionnel
+
+**Événements** :
+- `sh-session-click` - Émis au clic sur "Enregistrer session". `detail: { name, status }`
+- `sh-details-click` - Émis au clic sur "Détails". `detail: { name, category, status }`
+- `sh-edit-click` - Émis au clic sur éditer. `detail: { name, status }`
+- `sh-delete-click` - Émis au clic sur supprimer. `detail: { name, status }`
+
+```html
+<sh-stock-card
+  name="Acrylique Bleu Cobalt"
+  category="Peinture"
+  lastUpdate="il y a 3h"
+  percentage="65"
+  quantity="1 tube"
+  value="€12"
+  status="optimal"
+></sh-stock-card>
+```
+
+#### `<sh-stock-item-card>`
+Carte de produit pour l'inventaire familial avec statut, métriques et actions.
+
+**Props** :
+- `name`: string - Nom du produit
+- `sku`: string - Code SKU du produit
+- `quantity`: string | number - Quantité en stock
+- `value`: string - Valeur totale (optionnel)
+- `location`: string - Emplacement (optionnel, ex: "Atelier - Étagère 3")
+- `status`: `"optimal"` | `"low"` | `"critical"` | `"out-of-stock"` | `"overstocked"`
+- `loading`: boolean - État de chargement
+- `theme`: `"light"` | `"dark"`
+
+**Slots** :
+- `default` - Contenu personnalisé additionnel
+
+**Événements** :
+- `sh-view-click` - Émis au clic sur "Voir"
+- `sh-edit-click` - Émis au clic sur "Éditer"
+- `sh-delete-click` - Émis au clic sur "Supprimer"
+
+```html
+<!-- Produit en stock optimal -->
+<sh-stock-item-card
+  name="Peinture Acrylique 500ml - Bleu Cobalt"
+  sku="PNT-001"
+  quantity="45"
+  value="€675"
+  location="Atelier - Étagère 3"
+  status="optimal"
+></sh-stock-item-card>
+
+<!-- Stock faible -->
+<sh-stock-item-card
+  name="Crayons Aquarelle (Boîte de 24)"
+  sku="CRY-042"
+  quantity="8"
+  value="€240"
+  location="Bureau - Tiroir 2"
+  status="low"
+></sh-stock-item-card>
+
+<!-- Écouter les événements -->
+<script>
+  const card = document.querySelector('sh-stock-item-card');
+  card.addEventListener('sh-view-click', (e) => {
+    console.log('View:', e.detail); // { name, sku, status }
+  });
+  card.addEventListener('sh-edit-click', (e) => {
+    console.log('Edit:', e.detail);
+  });
+  card.addEventListener('sh-delete-click', (e) => {
+    console.log('Delete:', e.detail);
+  });
+</script>
 ```
 
 #### `<sh-collaborator-list>`

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@
 
 Ce Design System a été créé pour **StockHub V2**, une application de gestion de stock avec intelligence artificielle.
 
-Le projet contient **18 composants Web Components réutilisables** couvrant tous les besoins de l'application :
-- **Composants de base (atoms)** : badges, icônes Lucide, inputs, logo, texte
-- **Composants composés (molecules)** : buttons, cards, metric-card, search, status-badge, quantity-input, stat-card
-- **Composants complexes (organisms)** : header, footer, page-header, ia-alert-banner, stock-card, stock-item-card, stock-prediction-card
+Le projet contient **24 composants Web Components réutilisables** couvrant tous les besoins de l'application :
+- **Composants de base (atoms)** : badges, badge de rôle, icônes Lucide, inputs, logo, texte
+- **Composants composés (molecules)** : buttons, cards, metric-card, search, status-badge, quantity-input, stat-card, sélecteur de rôle, carte et formulaire de contribution
+- **Composants complexes (organisms)** : header, footer, page-header, ia-alert-banner, stock-card, stock-item-card, stock-prediction-card, liste de collaborateurs
 
 Développé selon la **méthodologie Atomic Design** avec une approche progressive et itérative. Le projet évolue continuellement en fonction des besoins de StockHub V2.
 
@@ -44,33 +44,39 @@ Développé selon la **méthodologie Atomic Design** avec une approche progressi
 ```
 src/
 ├── components/
-│   ├── atoms/                    # Composants de base (5)
+│   ├── atoms/                    # Composants de base (6)
 │   │   ├── badge/               # sh-badge
 │   │   ├── icon/                # sh-icon (Lucide)
 │   │   ├── input/               # sh-input
 │   │   ├── logo/                # sh-logo
+│   │   ├── role-badge/          # sh-role-badge
 │   │   └── text/                # sh-text
-│   ├── molecules/                # Combinaisons d'atoms (7)
+│   ├── molecules/                # Combinaisons d'atoms (10)
 │   │   ├── button/              # sh-button (ghost, loading, icons)
 │   │   ├── card/                # sh-card (base)
+│   │   ├── contribution-card/   # sh-contribution-card
+│   │   ├── contribution-form/   # sh-contribution-form
 │   │   ├── metric-card/         # sh-metric-card
 │   │   ├── quantity-input/      # sh-quantity-input
+│   │   ├── role-selector/       # sh-role-selector
 │   │   ├── search-input/        # sh-search-input
-│   │   ├── stat-card/           # sh-stat-card ✨ NEW
+│   │   ├── stat-card/           # sh-stat-card
 │   │   └── status-badge/        # sh-status-badge
-│   └── organisms/                # Composants complexes (7)
-│       ├── footer/              # sh-footer ✨ NEW
+│   └── organisms/                # Composants complexes (8)
+│       ├── collaborator-list/   # sh-collaborator-list
+│       ├── footer/              # sh-footer
 │       ├── header/              # sh-header
-│       ├── ia-alert-banner/     # sh-ia-alert-banner ✨ NEW
+│       ├── ia-alert-banner/     # sh-ia-alert-banner
+│       ├── page-header/         # sh-page-header
 │       ├── stock-card/          # sh-stock-card
 │       ├── stock-item-card/     # sh-stock-item-card
-│       └── stock-prediction-card/ # sh-stock-prediction-card ✨ NEW
+│       └── stock-prediction-card/ # sh-stock-prediction-card
 ├── tokens/                       # Design tokens (colors, spacing, etc.)
 ├── icons/                        # DEPRECATED: Remplacé par Lucide
 └── styles/                       # Global styles et CSS utilities
 ```
 
-**Total : 18 composants Web Components**
+**Total : 24 composants Web Components**
 
 ### Convention de Nommage
 Tous les composants utilisent le préfixe `sh-` (StockHub) :
@@ -194,6 +200,18 @@ Composant texte typographique.
 Logo StockHub avec variants.
 ```html
 <sh-logo style="--logo-size: 150px;"></sh-logo>
+```
+
+#### `<sh-role-badge>`
+Badge affichant le rôle d'un collaborateur sur un stock partagé.
+
+**Props** :
+- `role`: `"OWNER"` | `"EDITOR"` | `"VIEWER"` | `"VIEWER_CONTRIBUTOR"` (défaut : `"VIEWER"`)
+- `size`: `"sm"` | `"md"` | `"lg"` (défaut : `"md"`)
+
+```html
+<sh-role-badge role="OWNER"></sh-role-badge>
+<sh-role-badge role="VIEWER_CONTRIBUTOR" size="sm"></sh-role-badge>
 ```
 
 ### Molecules (Combinaisons)
@@ -387,6 +405,69 @@ Input numérique avec boutons +/-.
 ></sh-quantity-input>
 ```
 
+#### `<sh-role-selector>`
+Dropdown pour sélectionner le rôle d'un collaborateur.
+
+**Props** :
+- `value`: `"OWNER"` | `"EDITOR"` | `"VIEWER"` | `"VIEWER_CONTRIBUTOR"` (défaut : `"VIEWER"`)
+- `exclude`: string - Rôles à exclure de la liste, séparés par virgule (ex: `"OWNER"` pour un EDITOR qui ne peut pas attribuer OWNER)
+- `disabled`: boolean
+
+**Événements** :
+- `sh-role-change` - Émis au changement. `detail: { role: StockRole }`
+
+```html
+<sh-role-selector value="EDITOR"></sh-role-selector>
+<sh-role-selector value="VIEWER" exclude="OWNER"></sh-role-selector>
+```
+
+#### `<sh-contribution-card>`
+Carte affichant une contribution en attente (suggestion de quantité), avec actions approuver/rejeter.
+
+**Props** :
+- `contribution-id`: string
+- `item-label`: string - Nom de l'item concerné
+- `current-quantity`: number
+- `suggested-quantity`: number
+- `author-email`: string
+- `created-at`: string - Date ISO (optionnel)
+- `status`: `"PENDING"` | `"APPROVED"` | `"REJECTED"` (défaut : `"PENDING"`)
+- `disabled`: boolean - Désactive les actions (ex: pendant le traitement)
+
+**Événements** :
+- `sh-contribution-approve` - Émis au clic "Approuver". `detail: { contributionId: string }`
+- `sh-contribution-reject` - Émis au clic "Rejeter". `detail: { contributionId: string }`
+
+```html
+<sh-contribution-card
+  contribution-id="42"
+  item-label="Lait"
+  current-quantity="3"
+  suggested-quantity="1"
+  author-email="enfant@family.local"
+  status="PENDING"
+></sh-contribution-card>
+```
+
+#### `<sh-contribution-form>`
+Formulaire de soumission d'une contribution de quantité par un `VIEWER_CONTRIBUTOR`.
+
+**Props** :
+- `item-label`: string
+- `current-quantity`: number - Affiché en lecture seule
+- `disabled`: boolean
+
+**Événements** :
+- `sh-contribution-submit` - Émis à la soumission. `detail: { suggestedQuantity: number }`
+- `sh-contribution-cancel` - Émis à l'annulation.
+
+```html
+<sh-contribution-form
+  item-label="Lait"
+  current-quantity="3"
+></sh-contribution-form>
+```
+
 ### Organisms (Complexes)
 
 #### `<sh-stock-prediction-card>` 🆕 NOUVEAU
@@ -464,6 +545,25 @@ Carte de prédiction ML pour afficher les ruptures de stock prévues avec analys
 Header de l'application.
 ```html
 <sh-header userName="Sandrine" isLoggedIn></sh-header>
+```
+
+#### `<sh-collaborator-list>`
+Liste des collaborateurs d'un stock avec actions modifier le rôle / retirer, selon le rôle de l'utilisateur connecté.
+
+**Props** :
+- `collaborators`: `CollaboratorItem[]` - Accepte un tableau JS ou un JSON stringifié en attribut (`{ id: number, userEmail: string, role: StockRole }[]`)
+- `viewer-role`: `"OWNER"` | `"EDITOR"` | `"VIEWER"` | `"VIEWER_CONTRIBUTOR"` - Rôle de l'utilisateur connecté, détermine les actions disponibles
+- `disabled`: boolean - Désactive toutes les actions
+
+**Événements** :
+- `sh-collaborator-role-change` - Émis quand un rôle est modifié. `detail: { collaboratorId: number, role: StockRole }`
+- `sh-collaborator-remove` - Émis quand un collaborateur est retiré. `detail: { collaboratorId: number }`
+
+```html
+<sh-collaborator-list
+  collaborators='[{"id":1,"userEmail":"alice@example.com","role":"EDITOR"}]'
+  viewer-role="OWNER"
+></sh-collaborator-list>
 ```
 
 ## 📖 Storybook


### PR DESCRIPTION
## 🔗 Issue liée
Closes #48

## 📋 Description
sh-role-badge, sh-role-selector, sh-contribution-card, sh-contribution-form et sh-collaborator-list (issue #35, PR #37) n'apparaissaient jamais dans le README. Documentés avec leurs props/événements exacts, vérifiés contre le code source (pas d'invention).

## 🔧 Détails d'implémentation
- Ajout des 5 composants dans les sections Atoms/Molecules/Organisms, format identique aux entrées existantes
- Correction du compte total de composants : 18 → 24 (le compte précédent oubliait déjà `sh-page-header`)
- Noms d'événements documentés post-renommage issue #42 (préfixe `sh-`)
- Gap restant, hors scope : `sh-footer`, `sh-page-header`, `sh-ia-alert-banner`, `sh-stock-card`, `sh-stock-item-card` ne sont pas non plus documentés (antérieur à la PR #37) — flaggé séparément

## ✅ Checklist
- [x] `npm run lint` : 0 erreur
- [x] `npm run build` : passant
- [ ] GitHub Project mis à jour

## 📸 Screenshots
Aucun changement UI (documentation uniquement).