### PR TITLE
fix(sh-header): supprimer les attributs title natifs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2355,9 +2355,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2375,9 +2372,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2395,9 +2389,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2415,9 +2406,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2435,9 +2423,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2455,9 +2440,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2475,9 +2457,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2495,9 +2474,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2763,9 +2739,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2780,9 +2753,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2797,9 +2767,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2814,9 +2781,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2831,9 +2795,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2848,9 +2809,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2865,9 +2823,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2882,9 +2837,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/components/organisms/header/sh-header.ts
+++ b/src/components/organisms/header/sh-header.ts
@@ -236,7 +236,6 @@ export class ShHeader extends LitElement {
                                 class="notification-btn"
                                 @click="${this._handleNotificationClick}"
                                 aria-label="Notifications (${this.notificationCount} non lues)"
-                                title="Notifications"
                             >
                                 <sh-icon name="Bell" size="md"></sh-icon>
                                 ${this.notificationCount > 0 ? html`
@@ -253,7 +252,6 @@ export class ShHeader extends LitElement {
                                 icon-before="${this.theme === 'dark' ? 'Sun' : 'Moon'}"
                                 @click="${this._handleThemeToggle}"
                                 .ariaLabel="Changer vers le thème ${this.theme === 'dark' ? 'clair' : 'sombre'}"
-                                title="Changer de thème"
                             ></sh-button>
 
                             <!-- User Section -->
@@ -269,7 +267,6 @@ export class ShHeader extends LitElement {
                                         icon-before="LogOut"
                                         @click="${this._handleLogoutClick}"
                                         .ariaLabel="Se déconnecter de l'application StockHub"
-                                        title="Se déconnecter"
                                     >
                                         <span class="logout-text-desktop">Logout</span>
                                     </sh-button>
@@ -280,7 +277,6 @@ export class ShHeader extends LitElement {
                                         icon-before="LogIn"
                                         @click="${this._handleLoginClick}"
                                         .ariaLabel="Se connecter à StockHub"
-                                        title="Se connecter"
                                     >
                                         <span class="logout-text-desktop">Login</span>
                                     </sh-button>


### PR DESCRIPTION
## 🔗 Issue liée
Closes #39

## 📋 Description
Les boutons notifications, bascule de thème et connexion/déconnexion de `sh-header` affichaient un tooltip natif du navigateur (`title="..."`) en plus du tooltip personnalisé du Front, créant un conflit visuel.

## 🔧 Détails d'implémentation
- Suppression de `title="Notifications"`, `title="Changer de thème"`, `title="Se déconnecter"`, `title="Se connecter"`
- Les 3 boutons conservent leur `aria-label`/`.ariaLabel` explicite déjà en place — aucune perte d'accessibilité
- **Hors scope, signalé séparément** : `<span class="user-name">` (ligne 262) a aussi un `title="${this.userName}"` du même acabit, mais n'est pas listé dans les critères d'acceptation de #39 (qui ne cite que les 3 boutons) — pas touché ici

## ✅ Checklist
- [x] `npm run audit:conventions` : 0 problème
- [x] `npm run lint` : 0 erreur
- [x] `npm run build` : passant
- [x] Accessibilité vérifiée : aria-label conservés sur les 3 boutons
- [ ] GitHub Project mis à jour

## 📸 Screenshots
Aucun changement visuel (le title natif n'apparaissait qu'au survol).