### PR TITLE
fix(sh-header): supprimer le title natif redondant sur .user-name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2355,9 +2355,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2375,9 +2372,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2395,9 +2389,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2415,9 +2406,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2435,9 +2423,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2455,9 +2440,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2475,9 +2457,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2495,9 +2474,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2763,9 +2739,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2780,9 +2753,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2797,9 +2767,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2814,9 +2781,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2831,9 +2795,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2848,9 +2809,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2865,9 +2823,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2882,9 +2837,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/components/organisms/header/sh-header.ts
+++ b/src/components/organisms/header/sh-header.ts
@@ -259,7 +259,7 @@ export class ShHeader extends LitElement {
                             <!-- User Section -->
                             <div class="user-section">
                                 ${this.isLoggedIn ? html`
-                                    <span class="user-name" aria-label="Utilisateur connecté" title="${this.userName}">
+                                    <span class="user-name" aria-label="Utilisateur connecté">
                                         ${this.userName}
                                     </span>
 


### PR DESCRIPTION
## 🔗 Issue liée
Closes #76

## 📋 Description
Suite à #39 / PR #75 (boutons notifications/thème/connexion), le `<span class="user-name">` de `sh-header` avait été identifié comme présentant le même problème mais volontairement laissé hors scope.

## 🔧 Détails d'implémentation
- Suppression de `title="${this.userName}"` sur le span `.user-name`
- Vérifié : aucune règle CSS de troncature (`overflow`, `text-overflow`, `max-width`) sur `.user-name` — le title dupliquait exactement le texte déjà visible, ce n'était pas un fallback légitime pour un nom tronqué
- `aria-label="Utilisateur connecté"` conservé — aucune perte d'accessibilité

## ✅ Checklist
- [x] `npm run audit:conventions` : 0 problème
- [x] `npm run lint` : 0 erreur

## 📸 Screenshots
Aucun changement visuel (le title natif n'apparaissait qu'au survol).