### PR TITLE
fix: corriger aria-label casse sur boutons Login/Logout de sh-header

### DIFF
--- a/src/components/organisms/header/sh-header.ts
+++ b/src/components/organisms/header/sh-header.ts
@@ -266,7 +266,7 @@ export class ShHeader extends LitElement {
                                         size="sm"
                                         icon-before="LogOut"
                                         @click="${this._handleLogoutClick}"
-                                        .ariaLabel="Se déconnecter de l'application StockHub"
+                                        aria-label="Se déconnecter de l'application StockHub"
                                     >
                                         <span class="logout-text-desktop">Logout</span>
                                     </sh-button>
@@ -276,7 +276,7 @@ export class ShHeader extends LitElement {
                                         size="sm"
                                         icon-before="LogIn"
                                         @click="${this._handleLoginClick}"
-                                        .ariaLabel="Se connecter à StockHub"
+                                        aria-label="Se connecter à StockHub"
                                     >
                                         <span class="logout-text-desktop">Login</span>
                                     </sh-button>


### PR DESCRIPTION
## 🔗 Issue liée
Closes #78

## 📋 Description
Les boutons Login/Logout de `sh-header` n'avaient jamais de `aria-label` fonctionnel pour les lecteurs d'écran, malgré le JSDoc annonçant le contraire.

## 🔧 Détails d'implémentation
`.ariaLabel="chaîne statique"` n'est pas reconnu comme binding de propriété par lit-html : les préfixes `.`/`@`/`?` ne sont activés qu'en présence d'une interpolation `${}`, ce qui n'était pas le cas ici (contrairement au bouton theme-toggle du même composant, qui fonctionne car il interpole ${this.theme}).

Remplacé par l'attribut standard `aria-label="..."` sur les deux boutons (`_handleLogoutClick`, `_handleLoginClick`) dans `src/components/organisms/header/sh-header.ts`. `sh-button` déclare déjà `ariaLabel` avec `attribute: 'aria-label'`, donc l'attribut est correctement reflété en propriété et propagé au `<button>` interne du Shadow DOM.

Vérifié en conditions réelles dans Storybook (états `isLoggedIn=true` et `isLoggedIn=false`) : `aria-label` bien présent sur le `<button>` interne dans les deux cas.

Diff volontairement scopé aux 2 lignes concernées — le fichier a une dette Prettier pré-existante (#43) non traitée ici.

## ✅ Checklist
- [x] `npm run lint` passant (0 erreur, 70 warnings pré-existants inchangés)
- [x] `npm run build` passant
- [x] `npm run audit:conventions` passant
- [x] Accessibilité vérifiée manuellement (aria-label propagé au Shadow DOM, Login + Logout)
- [ ] GitHub Project mis à jour

## 📸 Screenshots
Changement non visuel (attribut d'accessibilité uniquement, aucun impact rendu).